### PR TITLE
Relative imports

### DIFF
--- a/maec/analytics/__init__.py
+++ b/maec/analytics/__init__.py
@@ -1,0 +1,2 @@
+from .distance import Distance, StaticFeatureVector, DynamicFeatureVector
+from .static_features import static_features_dict

--- a/maec/bundle/__init__.py
+++ b/maec/bundle/__init__.py
@@ -3,6 +3,7 @@ _namespace = 'http://maec.mitre.org/XMLSchema/maec-bundle-4'
 import maec
 from .malware_action import (MalwareAction, ActionImplementation, APICall,
                              ParameterList, Parameter)
+from .object_reference import ObjectReferenceList, ObjectReference
 from .av_classification import AVClassification, AVClassifications
 from .behavior_reference import BehaviorReference
 from .behavior import (Behavior, AssociatedCode, BehaviorPurpose, Exploit,
@@ -19,7 +20,6 @@ from .capability import (CapabilityList, Capability, CapabilityObjective,
                          CapabilityObjectiveRelationship, CapabilityReference,
                          CapabilityObjectiveReference)
 from .object_history import ObjectHistoryEntry, ObjectHistory
-from .object_reference import ObjectReferenceList, ObjectReference
 from .bundle import (Bundle, BehaviorReference, Collections,
                      CandidateIndicatorCollectionList, ObjectCollectionList,
                      ActionCollectionList, BehaviorCollectionList, 

--- a/maec/bundle/__init__.py
+++ b/maec/bundle/__init__.py
@@ -1,1 +1,30 @@
 _namespace = 'http://maec.mitre.org/XMLSchema/maec-bundle-4'
+
+import maec
+from .malware_action import (MalwareAction, ActionImplementation, APICall,
+                             ParameterList, Parameter)
+from .av_classification import AVClassification, AVClassifications
+from .behavior_reference import BehaviorReference
+from .behavior import (Behavior, AssociatedCode, BehaviorPurpose, Exploit,
+                       CVEVulnerability, PlatformList, BehavioralActions,
+                       BehavioralAction, BehavioralActionReference,
+                       BehavioralActionEquivalenceReference)
+from .action_reference_list import ActionReferenceList
+from .candidate_indicator import (CandidateIndicatorList, CandidateIndicator,
+                                  CandidateIndicatorComposition, MalwareEntity)
+from .process_tree import ProcessTree, ProcessTreeNode
+from .bundle_reference import BundleReference
+from .capability import (CapabilityList, Capability, CapabilityObjective,
+                         CapabilityProperty, CapabilityRelationship,
+                         CapabilityObjectiveRelationship, CapabilityReference,
+                         CapabilityObjectiveReference)
+from .object_history import ObjectHistoryEntry, ObjectHistory
+from .object_reference import ObjectReferenceList, ObjectReference
+from .bundle import (Bundle, BehaviorReference, Collections,
+                     CandidateIndicatorCollectionList, ObjectCollectionList,
+                     ActionCollectionList, BehaviorCollectionList, 
+                     CandidateIndicatorCollection, ObjectCollection,
+                     BehaviorCollection, ActionCollection, BaseCollection,
+                     ObjectList, ActionList, BehaviorList)
+
+

--- a/maec/bundle/action_reference_list.py
+++ b/maec/bundle/action_reference_list.py
@@ -9,6 +9,7 @@
 from cybox.core import ActionReference
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 
 
@@ -16,5 +17,5 @@ class ActionReferenceList(maec.EntityList):
     _contained_type = ActionReference
     _binding_class = bundle_binding.ActionReferenceListType
     _binding_var = "Action_Reference"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
      

--- a/maec/bundle/av_classification.py
+++ b/maec/bundle/av_classification.py
@@ -7,11 +7,12 @@
 # Last updated 09/26/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 from cybox.common import ToolInformation
 
 class AVClassification(ToolInformation, maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.AVClassificationType
 
@@ -66,4 +67,4 @@ class AVClassifications(maec.EntityList):
     _contained_type = AVClassification
     _binding_class = bundle_binding.AVClassificationsType
     _binding_var = "AV_Classification"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace

--- a/maec/bundle/behavior.py
+++ b/maec/bundle/behavior.py
@@ -9,10 +9,10 @@
 import maec
 from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
+from maec.bundle import MalwareAction
 from cybox.core.action_reference import ActionReference
 from cybox.common.measuresource import MeasureSource
 from cybox.common.platform_specification import PlatformSpecification
-from maec.bundle.malware_action import MalwareAction
 from cybox.objects.code_object import Code
 #from maec.bundle.bundle import ActionCollection
 import datetime

--- a/maec/bundle/behavior.py
+++ b/maec/bundle/behavior.py
@@ -7,6 +7,7 @@
 # Last updated 08/27/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 from cybox.core.action_reference import ActionReference
 from cybox.common.measuresource import MeasureSource
@@ -19,7 +20,7 @@ import datetime
 class BehavioralActionEquivalenceReference(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehavioralActionEquivalenceReferenceType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     action_equivalence_idref = maec.TypedField('action_equivalence_idref')
     behavioral_ordering = maec.TypedField('behavioral_ordering')
@@ -27,21 +28,21 @@ class BehavioralActionEquivalenceReference(maec.Entity):
 class BehavioralActionReference(ActionReference):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehavioralActionReferenceType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     behavioral_ordering = maec.TypedField('behavioral_ordering')
 
 class BehavioralAction(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehavioralActionType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     behavioral_ordering = maec.TypedField('behavioral_ordering')
 
 class BehavioralActions(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehavioralActionsType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     #action_collection = maec.TypedField('Action_Collection', ActionCollection, multiple=True) #TODO: solve recursive import
     action = maec.TypedField('Action', BehavioralAction, multiple=True)
@@ -53,12 +54,12 @@ class PlatformList(maec.EntityList):
     _binding_class = bundle_binding.PlatformListType
     _binding_var = "Platform"
     _contained_type = PlatformSpecification    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
 class CVEVulnerability(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.CVEVulnerabilityType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     cve_id = maec.TypedField('cve_id')
     description = maec.TypedField('Description')
@@ -66,7 +67,7 @@ class CVEVulnerability(maec.Entity):
 class Exploit(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.ExploitType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     
     known_vulnerability = maec.TypedField('known_vulnerability')
     cve = maec.TypedField('CVE', CVEVulnerability)
@@ -76,7 +77,7 @@ class Exploit(maec.Entity):
 class BehaviorPurpose(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehaviorPurposeType       
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     description = maec.TypedField('Description')
     vulnerability_exploit = maec.TypedField('Vulnerability_Exploit', Exploit)
@@ -86,12 +87,12 @@ class AssociatedCode(maec.EntityList):
     _binding_class = bundle_binding.AssociatedCodeType
     _binding_var = "Code_Snippet"
     _contained_type = Code    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
 class Behavior(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehaviorType  
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField('id')
     ordinal_position = maec.TypedField('ordinal_position')

--- a/maec/bundle/behavior_reference.py
+++ b/maec/bundle/behavior_reference.py
@@ -7,12 +7,13 @@
 # Last updated 08/28/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
        
 class BehaviorReference(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehaviorReferenceType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     behavior_idref = maec.TypedField("behavior_idref")
 

--- a/maec/bundle/bundle.py
+++ b/maec/bundle/bundle.py
@@ -13,41 +13,37 @@ from cybox.core import Object
 from cybox.utils.normalize import normalize_object_properties
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
-from maec.bundle.malware_action import MalwareAction
-from maec.bundle.av_classification import AVClassifications
-from maec.bundle.behavior import Behavior
-from maec.bundle.candidate_indicator import CandidateIndicator, CandidateIndicatorList
-from maec.bundle.action_reference_list import ActionReferenceList
-from maec.bundle.process_tree import ProcessTree
-from maec.bundle.capability import CapabilityList
-from maec.bundle.object_history import ObjectHistory
-from maec.utils.comparator import BundleComparator
-from maec.utils.deduplicator import BundleDeduplicator
+from maec.bundle import (MalwareAction, AVClassifications, Behavior, 
+                         CandidateIndicator, CandidateIndicatorList,
+                         ActionReferenceList, ProcessTree, CapabilityList,
+                         ObjectHistory)
+from maec.utils import BundleComparator, BundleDeduplicator
 
 
 class BehaviorList(maec.EntityList):
     _contained_type = Behavior
     _binding_class = bundle_binding.BehaviorListType
     _binding_var = "Behavior"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
 class ActionList(maec.EntityList):
     _contained_type = MalwareAction
     _binding_class = bundle_binding.ActionListType
     _binding_var = "Action"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     
 class ObjectList(maec.EntityList):
     _contained_type = Object
     _binding_class = bundle_binding.ObjectListType
     _binding_var = "Object"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
 class BaseCollection(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BaseCollectionType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     name = maec.TypedField("name")
     affinity_type = maec.TypedField("Affinity_Type")
@@ -61,7 +57,7 @@ class BaseCollection(maec.Entity):
 class ActionCollection(BaseCollection):
     _binding = bundle_binding
     _binding_class = bundle_binding.ActionCollectionType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     action_list = maec.TypedField("Action_List", ActionList)
@@ -81,7 +77,7 @@ class ActionCollection(BaseCollection):
 class BehaviorCollection(BaseCollection):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehaviorCollectionType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     behavior_list = maec.TypedField("Behavior_List", BehaviorList)
@@ -101,7 +97,7 @@ class BehaviorCollection(BaseCollection):
 class ObjectCollection(BaseCollection):
     _binding = bundle_binding
     _binding_class = bundle_binding.ObjectCollectionType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     object_list = maec.TypedField("Object_List", ObjectList)
@@ -121,7 +117,7 @@ class ObjectCollection(BaseCollection):
 class CandidateIndicatorCollection(BaseCollection):
     _binding = bundle_binding
     _binding_class = bundle_binding.CandidateIndicatorCollectionType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     candidate_indicator_list = maec.TypedField("Candidate_Indicator_List", CandidateIndicatorList)
@@ -142,7 +138,7 @@ class BehaviorCollectionList(maec.EntityList):
     _contained_type = BehaviorCollection
     _binding_class = bundle_binding.BehaviorCollectionListType
     _binding_var = "Behavior_Collection"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     def __init__(self):
         super(BehaviorCollectionList, self).__init__()
@@ -175,7 +171,7 @@ class ActionCollectionList(maec.EntityList):
     _contained_type = ActionCollection
     _binding_class = bundle_binding.ActionCollectionListType
     _binding_var = "Action_Collection"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     def __init__(self):
         super(ActionCollectionList, self).__init__()
@@ -208,7 +204,7 @@ class ObjectCollectionList(maec.EntityList):
     _contained_type = ObjectCollection
     _binding_class = bundle_binding.ObjectCollectionListType
     _binding_var = "Object_Collection"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     def __init__(self):
         super(ObjectCollectionList, self).__init__()
@@ -241,7 +237,7 @@ class CandidateIndicatorCollectionList(maec.EntityList):
     _contained_type = CandidateIndicatorCollection
     _binding_class = bundle_binding.CandidateIndicatorCollectionListType
     _binding_var = "Candidate_Indicator_Collection"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     def __init__(self):
         super(CandidateIndicatorCollectionList, self).__init__()
@@ -273,7 +269,7 @@ class CandidateIndicatorCollectionList(maec.EntityList):
 class Collections(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.CollectionsType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     behavior_collections = maec.TypedField("Behavior_Collections", BehaviorCollectionList)
     action_collections = maec.TypedField("Action_Collections", ActionCollectionList)
@@ -322,13 +318,13 @@ class Collections(maec.Entity):
 class BehaviorReference(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.BehaviorReferenceType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     behavior_idref = maec.TypedField('behavior_idref')
 
 class Bundle(maec.Entity):
     _binding = bundle_binding
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding_class = bundle_binding.BundleType
 
     id_ = maec.TypedField("id")

--- a/maec/bundle/bundle_reference.py
+++ b/maec/bundle/bundle_reference.py
@@ -7,10 +7,11 @@
 #Last updated 08/14/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
        
 class BundleReference(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.BundleReferenceType
 

--- a/maec/bundle/candidate_indicator.py
+++ b/maec/bundle/candidate_indicator.py
@@ -9,8 +9,7 @@
 import maec
 from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
-from maec.bundle.object_reference import ObjectReference
-from maec.bundle.behavior_reference import BehaviorReference
+from maec.bundle import ObjectReference, BehaviorReference
 from cybox.common import VocabString
 from cybox.core import ActionReference
 

--- a/maec/bundle/candidate_indicator.py
+++ b/maec/bundle/candidate_indicator.py
@@ -7,6 +7,7 @@
 # Last updated 08/27/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 from maec.bundle.object_reference import ObjectReference
 from maec.bundle.behavior_reference import BehaviorReference
@@ -16,7 +17,7 @@ from cybox.core import ActionReference
 class MalwareEntity(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.MalwareEntityType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     type_ = maec.TypedField("Type", VocabString)
     name = maec.TypedField("Name")
@@ -28,7 +29,7 @@ class MalwareEntity(maec.Entity):
 class CandidateIndicatorComposition(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.CandidateIndicatorCompositionType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     operator = maec.TypedField("operator")
     behavior_reference = maec.TypedField("Behavior_Reference", BehaviorReference, multiple = True)
@@ -45,7 +46,7 @@ CandidateIndicatorComposition.sub_composition.type_ = CandidateIndicatorComposit
 class CandidateIndicator(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.CandidateIndicatorType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     creation_datetime = maec.TypedField("creation_datetime")
@@ -69,4 +70,4 @@ class CandidateIndicatorList(maec.EntityList):
     _contained_type = CandidateIndicator
     _binding_class = bundle_binding.CandidateIndicatorListType
     _binding_var = "Candidate_Indicator"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace

--- a/maec/bundle/capability.py
+++ b/maec/bundle/capability.py
@@ -7,12 +7,13 @@
 # Last updated 8/26/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 from maec.bundle.behavior_reference import BehaviorReference
 from cybox.common import VocabString, String
 
 class CapabilityObjectiveReference(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityObjectiveReferenceType
 
@@ -22,7 +23,7 @@ class CapabilityObjectiveReference(maec.Entity):
         super(CapabilityObjectiveReference, self).__init__()
         
 class CapabilityReference(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityReferenceType
 
@@ -32,7 +33,7 @@ class CapabilityReference(maec.Entity):
         super(CapabilityReference, self).__init__()
 
 class CapabilityObjectiveRelationship(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityObjectiveRelationshipType
 
@@ -44,7 +45,7 @@ class CapabilityObjectiveRelationship(maec.Entity):
         self.objective_reference = []
 
 class CapabilityRelationship(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityRelationshipType
 
@@ -56,7 +57,7 @@ class CapabilityRelationship(maec.Entity):
         self.capability_reference = []
 
 class CapabilityProperty(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityPropertyType
 
@@ -67,7 +68,7 @@ class CapabilityProperty(maec.Entity):
         super(CapabilityProperty, self).__init__()
 
 class CapabilityObjective(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityObjectiveType
 
@@ -86,7 +87,7 @@ class CapabilityObjective(maec.Entity):
             self.id_ = maec.utils.idgen.create_id(prefix="capability_objective")
 
 class Capability(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityType
 
@@ -120,7 +121,7 @@ class Capability(maec.Entity):
         self.strategic_objective.append(strategic_objective)
         
 class CapabilityList(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.CapabilityListType
 

--- a/maec/bundle/capability.py
+++ b/maec/bundle/capability.py
@@ -9,7 +9,7 @@
 import maec
 from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
-from maec.bundle.behavior_reference import BehaviorReference
+from maec.bundle import BehaviorReference
 from cybox.common import VocabString, String
 
 class CapabilityObjectiveReference(maec.Entity):

--- a/maec/bundle/malware_action.py
+++ b/maec/bundle/malware_action.py
@@ -11,10 +11,11 @@ from cybox.core import Action
 from cybox.objects.code_object import Code
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 
 class Parameter(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.ParameterType
 
@@ -29,10 +30,10 @@ class ParameterList(maec.EntityList):
     _contained_type = Parameter
     _binding_class = bundle_binding.ParameterListType
     _binding_var = "Parameter"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
 class APICall(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.APICallType
 
@@ -46,7 +47,7 @@ class APICall(maec.Entity):
         super(APICall, self).__init__()
 
 class ActionImplementation(maec.Entity):
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
     _binding = bundle_binding
     _binding_class = bundle_binding.ActionImplementationType
 
@@ -62,7 +63,7 @@ class ActionImplementation(maec.Entity):
 class MalwareAction(Action):
     _binding = bundle_binding
     _binding_class = bundle_binding.MalwareActionType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     implementation = cybox.TypedField("Implementation", ActionImplementation)
     

--- a/maec/bundle/object_reference.py
+++ b/maec/bundle/object_reference.py
@@ -7,12 +7,13 @@
 # Last updated 08/28/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding       
 
 class ObjectReference(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.ObjectReferenceType
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     def __init__(self, object_idref = None):
         super(ObjectReference, self).__init__()
@@ -22,4 +23,4 @@ class ObjectReferenceList(maec.EntityList):
     _contained_type = ObjectReference
     _binding_class = bundle_binding.ObjectReferenceListType
     _binding_var = "Object_Reference"
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace

--- a/maec/bundle/process_tree.py
+++ b/maec/bundle/process_tree.py
@@ -11,6 +11,7 @@ from cybox.objects.process_object import Process
 from cybox.core import ActionReference
 
 import maec
+from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
 from maec.bundle.action_reference_list import ActionReferenceList
 
@@ -108,7 +109,7 @@ class ProcessTreeNode(Process):
 class ProcessTree(maec.Entity):
     _binding = bundle_binding
     _binding_class = bundle_binding.ProcessTreeType    
-    _namespace = maec.bundle._namespace
+    _namespace = _namespace
 
     root_process = maec.TypedField("Root_Process", ProcessTreeNode)
 

--- a/maec/bundle/process_tree.py
+++ b/maec/bundle/process_tree.py
@@ -13,7 +13,7 @@ from cybox.core import ActionReference
 import maec
 from . import _namespace
 import maec.bindings.maec_bundle as bundle_binding
-from maec.bundle.action_reference_list import ActionReferenceList
+from maec.bundle import ActionReferenceList
 
 class ProcessTreeNode(Process):
     _binding = bundle_binding

--- a/maec/misc/__init__.py
+++ b/maec/misc/__init__.py
@@ -1,0 +1,3 @@
+from .exceptions import (LookupNotFoundException, NetworkFailureException,
+                         APIKeyException)
+from .options import ScriptOptions

--- a/maec/package/__init__.py
+++ b/maec/package/__init__.py
@@ -1,1 +1,29 @@
 _namespace = 'http://maec.mitre.org/XMLSchema/maec-package-2'
+
+import maec
+from .action_equivalence import ActionEquivalenceList, ActionEquivalence
+from .malware_subject_reference import MalwareSubjectReference
+from .object_equivalence import ObjectEquivalence, ObjectEquivalenceList
+from .analysis import (Analysis, AnalysisEnvironment, NetworkInfrastructure,
+                       CapturedProtocolList, CapturedProtocol, 
+                       AnalysisSystemList, AnalysisSystem, InstalledPrograms,
+                       HypervisorHostSystem, DynamicAnalysisMetadata, 
+                       ToolList, CommentList, Comment, Source)
+from .grouping_relationship import (GroupingRelationshipList, 
+                                    GroupingRelationship, ClusteringMetadata,
+                                    ClusteringAlgorithmParameters, 
+                                    ClusterComposition, ClusterEdgeNodePair)
+from .malware_subject import (MalwareSubjectList, MalwareSubject,
+                              MalwareConfigurationDetails, 
+                              MalwareConfigurationObfuscationDetails,
+                              MalwareConfigurationObfuscationAlgorithm, 
+                              MalwareConfigurationStorageDetails,
+                              MalwareBinaryConfigurationStorageDetails,
+                              MalwareConfigurationParameter, 
+                              MalwareDevelopmentEnvironment,
+                              FindingsBundleList, MetaAnalysis, 
+                              MalwareSubjectRelationshipList, 
+                              MalwareSubjectRelationship, Analyses, 
+                              MinorVariants)
+
+from .package import Package

--- a/maec/package/action_equivalence.py
+++ b/maec/package/action_equivalence.py
@@ -7,13 +7,14 @@
 #Last updated 08/20/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding
 from cybox.core import ActionReference
 
 class ActionEquivalence(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.ActionEquivalenceType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField('id')
     action_reference = maec.TypedField('Action_Reference', ActionReference, multiple = True)
@@ -26,4 +27,4 @@ class ActionEquivalenceList(maec.EntityList):
     _contained_type = ActionEquivalence
     _binding_class = package_binding.ActionEquivalenceListType
     _binding_var = "Action_Equivalence"
-    _namespace = maec.package._namespace
+    _namespace = _namespace

--- a/maec/package/analysis.py
+++ b/maec/package/analysis.py
@@ -12,13 +12,14 @@ from cybox.common import (PlatformSpecification, Personnel, StructuredText,
 from cybox.objects.system_object import System
 
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding
-from maec.bundle.bundle_reference import BundleReference
+from maec.bundle import BundleReference
 
 class Source(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.SourceType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     name = maec.TypedField("Name")
     method = maec.TypedField("Method")
@@ -32,7 +33,7 @@ class Source(maec.Entity):
 class Comment(StructuredText):
     _binding = package_binding
     _binding_class = package_binding.CommentType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     author = maec.TypedField("author")
     timestamp = maec.TypedField("timestamp")
@@ -53,18 +54,18 @@ class CommentList(maec.EntityList):
     _contained_type = Comment
     _binding_class = package_binding.CommentListType
     _binding_var = "Comment"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 class ToolList(maec.EntityList):
     _contained_type = ToolInformation
     _binding_class = package_binding.ToolListType
     _binding_var = "Tool"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 class DynamicAnalysisMetadata(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.DynamicAnalysisMetadataType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     command_line = maec.TypedField("Command_Line")
     analysis_duration = maec.TypedField("Analysis_Duration")
@@ -77,7 +78,7 @@ class DynamicAnalysisMetadata(maec.Entity):
 class HypervisorHostSystem(System):
     _binding = package_binding
     _binding_class = package_binding.HypervisorHostSystemType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     vm_hypervisor = maec.TypedField("VM_Hypervisor", PlatformSpecification)
 
@@ -88,12 +89,12 @@ class InstalledPrograms(maec.EntityList):
     _contained_type = PlatformSpecification
     _binding_class = package_binding.InstalledProgramsType
     _binding_var = "Program"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
         
 class AnalysisSystem(System):
     _binding = package_binding
     _binding_class = package_binding.AnalysisSystemType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     installed_programs = maec.TypedField("Installed_Programs", InstalledPrograms)
 
@@ -105,12 +106,12 @@ class AnalysisSystemList(maec.EntityList):
     _contained_type = AnalysisSystem
     _binding_class = package_binding.AnalysisSystemListType
     _binding_var = "Analysis_System"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 class CapturedProtocol(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.CapturedProtocolType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     layer7_protocol = maec.TypedField("layer7_protocol")
     layer4_protocol = maec.TypedField("layer4_protocol")
@@ -124,12 +125,12 @@ class CapturedProtocolList(maec.EntityList):
     _contained_type = CapturedProtocol
     _binding_class = package_binding.CapturedProtocolListType
     _binding_var = "Protocol"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 class NetworkInfrastructure(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.NetworkInfrastructureType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     captured_protocols = maec.TypedField("Captured_Protocols", CapturedProtocolList)
 
@@ -140,7 +141,7 @@ class NetworkInfrastructure(maec.Entity):
 class AnalysisEnvironment(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.AnalysisEnvironmentType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     hypervisor_host_system = maec.TypedField("Hypervisor_Host_System", HypervisorHostSystem)
     analysis_systems = maec.TypedField("Analysis_Systems", AnalysisSystemList)
@@ -152,7 +153,7 @@ class AnalysisEnvironment(maec.Entity):
 class Analysis(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.AnalysisType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     method = maec.TypedField("method")

--- a/maec/package/grouping_relationship.py
+++ b/maec/package/grouping_relationship.py
@@ -8,6 +8,7 @@
 
 import cybox
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding  
 from maec.package.malware_subject_reference import MalwareSubjectReference
 from cybox.common import VocabString
@@ -15,7 +16,7 @@ from cybox.common import VocabString
 class ClusterEdgeNodePair(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.ClusterEdgeNodePairType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
     
     similarity_index = maec.TypedField("similarity_index")
     similarity_distance = maec.TypedField("similarity_distance")
@@ -28,7 +29,7 @@ class ClusterEdgeNodePair(maec.Entity):
 class ClusterComposition(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.ClusterCompositionType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
     
     score_type = maec.TypedField("score_type")
     edge_node_pair = maec.TypedField("Edge_Node_Pair", ClusterEdgeNodePair, multiple=True)
@@ -39,7 +40,7 @@ class ClusterComposition(maec.Entity):
 class ClusteringAlgorithmParameters(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.ClusteringAlgorithmParametersType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     distance_threashold = maec.TypedField("Distance_Threashold")
     number_of_iterations = maec.TypedField("Number_of_Iterations")
@@ -50,7 +51,7 @@ class ClusteringAlgorithmParameters(maec.Entity):
 class ClusteringMetadata(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.ClusteringMetadataType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     algorithm_name = maec.TypedField("Algorithm_Name")
     algorithm_version = maec.TypedField("Algorithm_Version")
@@ -65,7 +66,7 @@ class ClusteringMetadata(maec.Entity):
 class GroupingRelationship(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.GroupingRelationshipType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     type_ = maec.TypedField("Type", VocabString)
     malware_family_name = maec.TypedField("Malware_Family_Name")
@@ -79,7 +80,7 @@ class GroupingRelationshipList(maec.EntityList):
     _contained_type = GroupingRelationship
     _binding_class = package_binding.GroupingRelationshipListType
     _binding_var = "Grouping_Relationship"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 
 

--- a/maec/package/malware_subject.py
+++ b/maec/package/malware_subject.py
@@ -13,29 +13,28 @@ from cybox.objects.uri_object import URI
 from cybox.core import Object
 
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding
-from maec.bundle.bundle import Bundle
-from maec.package.action_equivalence import ActionEquivalenceList
-from maec.package.analysis import Analysis
-from maec.package.malware_subject_reference import MalwareSubjectReference
-from maec.package.object_equivalence import ObjectEquivalenceList
+from maec.bundle import Bundle
+from maec.package import (ActionEquivalenceList, Analysis, 
+                          MalwareSubjectReference, ObjectEquivalenceList)
 
 class MinorVariants(maec.EntityList):
     _contained_type = Object
     _binding_class = package_binding.MinorVariantListType
     _binding_var = "Minor_Variant"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
     
 class Analyses(maec.EntityList):
     _contained_type = Analysis
     _binding_class = package_binding.AnalysisListType
     _binding_var = "Analysis"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 class MalwareSubjectRelationship(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareSubjectRelationshipType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     malware_subject_reference = maec.TypedField("Malware_Subject_Reference", MalwareSubjectReference, multiple = True)
     type_ = maec.TypedField("Type", VocabString)
@@ -48,12 +47,12 @@ class MalwareSubjectRelationshipList(maec.EntityList):
     _contained_type = MalwareSubjectRelationship
     _binding_class = package_binding.MalwareSubjectRelationshipListType
     _binding_var = "Relationship"
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
 class MetaAnalysis(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MetaAnalysisType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     action_equivalences = maec.TypedField("Action_Equivalences", ActionEquivalenceList)
     object_equivalences = maec.TypedField("Object_Equivalences", ObjectEquivalenceList)
@@ -64,7 +63,7 @@ class MetaAnalysis(maec.Entity):
 class FindingsBundleList(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.FindingsBundleListType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     meta_analysis = maec.TypedField("Meta_Analysis", MetaAnalysis)
     bundle = maec.TypedField("Bundle", Bundle, multiple = True)
@@ -86,7 +85,7 @@ class FindingsBundleList(maec.Entity):
 class MalwareDevelopmentEnvironment(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareDevelopmentEnvironmentType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     tools = maec.TypedField("Tools", ToolInformation)
     debugging_file = maec.TypedField("Debugging_File", File, multiple = True)
@@ -98,7 +97,7 @@ class MalwareDevelopmentEnvironment(maec.Entity):
 class MalwareConfigurationParameter(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareConfigurationParameterType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     name = maec.TypedField("Name", VocabString)
     value = maec.TypedField("Value")
@@ -110,7 +109,7 @@ class MalwareConfigurationParameter(maec.Entity):
 class MalwareBinaryConfigurationStorageDetails(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareBinaryConfigurationStorageDetailsType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     file_offset = maec.TypedField("File_Offset")
     section_name = maec.TypedField("Section_Name")
@@ -122,7 +121,7 @@ class MalwareBinaryConfigurationStorageDetails(maec.Entity):
 class MalwareConfigurationStorageDetails(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareConfigurationStorageDetailsType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     malware_binary = maec.TypedField("Malware_Binary", MalwareBinaryConfigurationStorageDetails)
     file = maec.TypedField("File", File)
@@ -134,7 +133,7 @@ class MalwareConfigurationStorageDetails(maec.Entity):
 class MalwareConfigurationObfuscationAlgorithm(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareConfigurationObfuscationAlgorithmType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     ordinal_position = maec.TypedField("ordinal_position")
     key = maec.TypedField("Key")
@@ -147,7 +146,7 @@ class MalwareConfigurationObfuscationAlgorithm(maec.Entity):
 class MalwareConfigurationObfuscationDetails(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareConfigurationObfuscationDetailsType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     is_encoded = maec.TypedField("is_encoded")
     is_encrypted = maec.TypedField("is_encrypted")
@@ -161,7 +160,7 @@ class MalwareConfigurationObfuscationDetails(maec.Entity):
 class MalwareConfigurationDetails(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareConfigurationDetailsType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     storage = maec.TypedField("Storage", MalwareConfigurationStorageDetails)
     obfuscation = maec.TypedField("Obfuscation", MalwareConfigurationObfuscationDetails)
@@ -173,7 +172,7 @@ class MalwareConfigurationDetails(maec.Entity):
 class MalwareSubject(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareSubjectType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     malware_instance_object_attributes = maec.TypedField("Malware_Instance_Object_Attributes", Object)
@@ -242,4 +241,4 @@ class MalwareSubjectList(maec.EntityList):
     _contained_type = MalwareSubject
     _binding_class = package_binding.MalwareSubjectListType
     _binding_var = "Malware_Subject"
-    _namespace = maec.package._namespace
+    _namespace = _namespace

--- a/maec/package/malware_subject_reference.py
+++ b/maec/package/malware_subject_reference.py
@@ -7,13 +7,14 @@
 #Last updated 08/20/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding
 import cybox
 
 class MalwareSubjectReference(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.MalwareSubjectReferenceType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     malware_subject_idref = maec.TypedField("malware_subject_idref")
 

--- a/maec/package/object_equivalence.py
+++ b/maec/package/object_equivalence.py
@@ -8,13 +8,14 @@
 
 import cybox
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding
-from maec.bundle.object_reference import ObjectReference    
+from maec.bundle import ObjectReference    
 
 class ObjectEquivalence(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.ObjectEquivalenceType
-    _namespace = maec.package._namespace
+    _namespace = _namespace
 
     id_ = maec.TypedField("id")
     object_reference = maec.TypedField("Object_Reference", ObjectReference, multiple = True)
@@ -27,4 +28,4 @@ class ObjectEquivalenceList(maec.EntityList):
     _contained_type = ObjectEquivalence
     _binding_class = package_binding.ObjectEquivalenceListType
     _binding_var = "Object_Equivalence"
-    _namespace = maec.package._namespace
+    _namespace = _namespace

--- a/maec/package/package.py
+++ b/maec/package/package.py
@@ -7,15 +7,15 @@
 #Last updated 08/20/2014
 
 import maec
+from . import _namespace
 import maec.bindings.maec_package as package_binding
-from maec.package.malware_subject import MalwareSubjectList
-from maec.package.grouping_relationship import GroupingRelationshipList
+from maec.package import MalwareSubjectList, GroupingRelationshipList
 from cybox.common import DateTime
 
 class Package(maec.Entity):
     _binding = package_binding
     _binding_class = package_binding.PackageType
-    _namespace = maec.package._namespace   
+    _namespace = _namespace   
 
     id_ = maec.TypedField('id')
     timestamp = maec.TypedField('timestamp')

--- a/maec/utils/__init__.py
+++ b/maec/utils/__init__.py
@@ -8,10 +8,13 @@
 #Last updated 02/18/2014
 
 """MAEC utility methods"""
-
+import maec
 from .nsparser import maecMETA
 from .idgen import *
 from .parser import EntityParser
+from .comparator import (ObjectHash, BundleComparator, SimilarObjectCluster,
+                         ComparisonResult)
+from .deduplicator import BundleDeduplicator
 
 
 

--- a/maec/utils/merge.py
+++ b/maec/utils/merge.py
@@ -9,12 +9,11 @@ from copy import deepcopy
 from cybox.core import Object
 from cybox.common import HashList
 from cybox.utils import Namespace
-from maec.package.package import Package
-from maec.bundle.bundle import Bundle
-from maec.package.malware_subject import (MalwareSubject, MalwareConfigurationDetails,
-                                          FindingsBundleList, MetaAnalysis, Analyses,
-                                          MinorVariants, MalwareSubjectRelationshipList,
-                                          MalwareSubjectList)
+from maec.bundle import Bundle
+from maec.package import (Package, MalwareSubject, MalwareConfigurationDetails,
+                          FindingsBundleList, MetaAnalysis, Analyses,
+                          MinorVariants, MalwareSubjectRelationshipList,
+                          MalwareSubjectList)
 
 def dict_merge(target, *args):
     '''Merge multiple dictionaries into one'''


### PR DESCRIPTION
Added relative imports for API classes. No longer will users need to do klugey stuff like `from maec.bundle.bundle import Bundle`. 