### PR TITLE
Input namespaces

### DIFF
--- a/maec/bundle/process_tree.py
+++ b/maec/bundle/process_tree.py
@@ -18,6 +18,7 @@ from maec.bundle import ActionReferenceList
 class ProcessTreeNode(Process):
     _binding = bundle_binding
     _binding_class = bundle_binding.ProcessTreeNodeType
+    _namespace = _namespace
     _XSI_NS = "maecBundle"
     _XSI_TYPE = "ProcessTreeNodeType"
     superclass = Process

--- a/maec/package/package.py
+++ b/maec/package/package.py
@@ -6,11 +6,15 @@
 #Compatible with MAEC v4.1
 #Last updated 08/20/2014
 
+from cybox.common import DateTime
+
 import maec
-from . import _namespace
 import maec.bindings.maec_package as package_binding
 from maec.package import MalwareSubjectList, GroupingRelationshipList
-from cybox.common import DateTime
+
+from . import _namespace
+
+
 
 class Package(maec.Entity):
     _binding = package_binding
@@ -45,7 +49,8 @@ class Package(maec.Entity):
         if not self.grouping_relationships:
             self.grouping_relationships = GroupingRelationshipList()
         self.grouping_relationships.append(grouping_relationship)
-        
+
+
     # Create new Package from the XML document at the specified path
     @staticmethod
     def from_xml(xml_file):
@@ -54,16 +59,11 @@ class Package(maec.Entity):
         Parameters:
         xml_file - either a filename or a stream object
         '''
-        
-        if isinstance(xml_file, basestring):
-            f = open(xml_file, "rb")
-        else:
-            f = xml_file
-        
-        doc = package_binding.parsexml_(f)
-        maec_package_obj = package_binding.PackageType().factory()
-        maec_package_obj.build(doc.getroot())
-        maec_package = Package.from_obj(maec_package_obj)
+        from maec.utils.parser import EntityParser
+
+        parser = EntityParser()
+        maec_package = parser.parse_xml(xml_file)
+        maec_package_obj = maec_package.to_obj()
         
         return (maec_package, maec_package_obj)
 

--- a/maec/utils/__init__.py
+++ b/maec/utils/__init__.py
@@ -1,13 +1,23 @@
-#MAEC Utility Methods
-
-#Copyright (c) 2015, The MITRE Corporation
-#All rights reserved
-
-
-#Compatible with MAEC v4.1
-#Last updated 02/18/2014
-
+# Copyright (c) 2015, The MITRE Corporation
+# All rights reserved
 """MAEC utility methods"""
+
+
+def flip_dict(d):
+    """Returns a copy of the input dictionary `d` where the values of `d`
+    become the keys and the keys become the values.
+
+    Note:
+        This does not even attempt to address key collisions.
+
+    Args:
+        d: A dictionary
+
+    """
+    return dict((v,k) for k, v in d.iteritems())
+
+
+# Namespace flattening
 import maec
 from .nsparser import maecMETA
 from .idgen import *
@@ -15,8 +25,3 @@ from .parser import EntityParser
 from .comparator import (ObjectHash, BundleComparator, SimilarObjectCluster,
                          ComparisonResult)
 from .deduplicator import BundleDeduplicator
-
-
-
-    
-

--- a/maec/utils/parser.py
+++ b/maec/utils/parser.py
@@ -62,9 +62,7 @@ class EntityParser(object):
         except AttributeError:
             root = tree
         
-        entity.__input_namespaces__ = {}
-        for alias,ns in root.nsmap.iteritems():
-            entity.__input_namespaces__[ns] = alias
+        entity.__input_namespaces__ = dict(root.nsmap.iteritems())
 
     def parse_xml_to_obj(self, xml_file, check_version=True):
         """Creates a MAEC binding object from the supplied xml file.


### PR DESCRIPTION
This PR attempts to align the organization of `__input_namespaces__` with python-stix, which is `prefix => namespace`.

* Added `_namespace` class attribute to `ProcessTreeNode`
* Refactored `Entity.to_xml_file()` to parse the new `__input_namespace__` layout.
* Refactored `Package.from_xml()` to use `maec.utils.parser.EntityParser` class.

If this is merged, the it will need to be released at the same time as the next python-stix release.