### PR TITLE
Fix for duplicated action collections

### DIFF
--- a/maec/bundle/bundle.py
+++ b/maec/bundle/bundle.py
@@ -181,6 +181,7 @@ class ActionCollectionList(maec.EntityList):
 
     def to_obj(self, ns_info=None):
         action_collection_list_obj = super(ActionCollectionList, self).to_obj()
+        action_collection_list_obj.set_Action_Collection([])
 
         for action_collection in self:
             if len(action_collection.action_list) > 0:


### PR DESCRIPTION
In python-maec 4.1.0.13 when an action collection list is translated to an object (and then to xml), action collections are duplicated and empty action collections are not removed. This PR fixes the problem.

## To reproduce the problem

```
from mixbox.idgen import IDGenerator, set_id_method
set_id_method(IDGenerator.METHOD_INT)

from cybox.core import Object, AssociatedObjects, AssociatedObject
from cybox.objects.file_object import File
from cybox.common import VocabString
from maec.bundle import Bundle
from maec.bundle import MalwareAction

b = Bundle()
b.add_named_action_collection('Test')
b.add_named_action_collection('Empty')

a = MalwareAction()
ao = AssociatedObject()

ao.properties = File()
ao.properties.file_name = "badware.exe"
ao.properties.size_in_bytes = "123456"
ao.association_type = VocabString()
ao.association_type.value = 'output'
ao.association_type.xsi_type = 'maecVocabs:ActionObjectAssociationTypeVocab-1.0'

a.name = VocabString()
a.name.value = 'create file'
a.name.xsi_type = 'maecVocabs:FileActionNameVocab-1.0'
a.associated_objects = AssociatedObjects()
a.associated_objects.append(ao)

b.add_action(a, 'Test')

print b.to_xml(pretty=True)
```

### Expected Result

```
<maecBundle:MAEC_Bundle xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2"
	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
	xmlns:cybox="http://cybox.mitre.org/cybox-2"
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	xmlns:example="http://example.com"
	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
	xmlns:maecBundle="http://maec.mitre.org/XMLSchema/maec-bundle-4"
	xmlns:xlink="http://www.w3.org/1999/xlink"

	xsi:schemaLocation="http://cybox.mitre.org/objects#FileObject-2 http://cybox.mitre.org/XMLSchema/objects/File/2.1/File_Object.xsd
	http://cybox.mitre.org/default_vocabularies-2 http://cybox.mitre.org/XMLSchema/default_vocabularies/2.1/cybox_default_vocabularies.xsd
	http://cybox.mitre.org/cybox-2 http://cybox.mitre.org/XMLSchema/core/2.1/cybox_core.xsd
	http://cybox.mitre.org/common-2 http://cybox.mitre.org/XMLSchema/common/2.1/cybox_common.xsd
	http://maec.mitre.org/XMLSchema/maec-bundle-4 http://maec.mitre.org/language/version4.1/maec_bundle_schema.xsd" defined_subject="false" id="example:bundle-1" schema_version="4.1">
    <maecBundle:Collections>
        <maecBundle:Action_Collections>
            <maecBundle:Action_Collection name="Test" id="example:action_collection-2">
                <maecBundle:Action_List>
                    <maecBundle:Action id="example:action-4">
                        <cybox:Name xsi:type="maecVocabs:FileActionNameVocab-1.0">create file</cybox:Name>
                        <cybox:Associated_Objects>
                            <cybox:Associated_Object id="example:Object-5">
                                <cybox:Properties xsi:type="FileObj:FileObjectType">
                                    <FileObj:File_Name>badware.exe</FileObj:File_Name>
                                    <FileObj:Size_In_Bytes>123456</FileObj:Size_In_Bytes>
                                </cybox:Properties>
                                <cybox:Association_Type xsi:type="maecVocabs:ActionObjectAssociationTypeVocab-1.0">output</cybox:Association_Type>
                            </cybox:Associated_Object>
                        </cybox:Associated_Objects>
                    </maecBundle:Action>
                </maecBundle:Action_List>
            </maecBundle:Action_Collection>
        </maecBundle:Action_Collections>
    </maecBundle:Collections>
</maecBundle:MAEC_Bundle>
```

### Actual Result

```
<maecBundle:MAEC_Bundle xmlns:FileObj="http://cybox.mitre.org/objects#FileObject-2"
	xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
	xmlns:cyboxVocabs="http://cybox.mitre.org/default_vocabularies-2"
	xmlns:cybox="http://cybox.mitre.org/cybox-2"
	xmlns:xs="http://www.w3.org/2001/XMLSchema"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	xmlns:example="http://example.com"
	xmlns:cyboxCommon="http://cybox.mitre.org/common-2"
	xmlns:maecBundle="http://maec.mitre.org/XMLSchema/maec-bundle-4"
	xmlns:xlink="http://www.w3.org/1999/xlink"

	xsi:schemaLocation="http://cybox.mitre.org/objects#FileObject-2 http://cybox.mitre.org/XMLSchema/objects/File/2.1/File_Object.xsd
	http://cybox.mitre.org/default_vocabularies-2 http://cybox.mitre.org/XMLSchema/default_vocabularies/2.1/cybox_default_vocabularies.xsd
	http://cybox.mitre.org/cybox-2 http://cybox.mitre.org/XMLSchema/core/2.1/cybox_core.xsd
	http://cybox.mitre.org/common-2 http://cybox.mitre.org/XMLSchema/common/2.1/cybox_common.xsd
	http://maec.mitre.org/XMLSchema/maec-bundle-4 http://maec.mitre.org/language/version4.1/maec_bundle_schema.xsd" defined_subject="false" id="example:bundle-1" schema_version="4.1">
    <maecBundle:Collections>
        <maecBundle:Action_Collections>
            <maecBundle:Action_Collection name="Test" id="example:action_collection-2">
                <maecBundle:Action_List>
                    <maecBundle:Action id="example:action-4">
                        <cybox:Name xsi:type="maecVocabs:FileActionNameVocab-1.0">create file</cybox:Name>
                        <cybox:Associated_Objects>
                            <cybox:Associated_Object id="example:Object-5">
                                <cybox:Properties xsi:type="FileObj:FileObjectType">
                                    <FileObj:File_Name>badware.exe</FileObj:File_Name>
                                    <FileObj:Size_In_Bytes>123456</FileObj:Size_In_Bytes>
                                </cybox:Properties>
                                <cybox:Association_Type xsi:type="maecVocabs:ActionObjectAssociationTypeVocab-1.0">output</cybox:Association_Type>
                            </cybox:Associated_Object>
                        </cybox:Associated_Objects>
                    </maecBundle:Action>
                </maecBundle:Action_List>
            </maecBundle:Action_Collection>
            <maecBundle:Action_Collection name="Empty" id="example:action_collection-3"/>
            <maecBundle:Action_Collection name="Test" id="example:action_collection-2">
                <maecBundle:Action_List>
                    <maecBundle:Action id="example:action-4">
                        <cybox:Name xsi:type="maecVocabs:FileActionNameVocab-1.0">create file</cybox:Name>
                        <cybox:Associated_Objects>
                            <cybox:Associated_Object id="example:Object-5">
                                <cybox:Properties xsi:type="FileObj:FileObjectType">
                                    <FileObj:File_Name>badware.exe</FileObj:File_Name>
                                    <FileObj:Size_In_Bytes>123456</FileObj:Size_In_Bytes>
                                </cybox:Properties>
                                <cybox:Association_Type xsi:type="maecVocabs:ActionObjectAssociationTypeVocab-1.0">output</cybox:Association_Type>
                            </cybox:Associated_Object>
                        </cybox:Associated_Objects>
                    </maecBundle:Action>
                </maecBundle:Action_List>
            </maecBundle:Action_Collection>
        </maecBundle:Action_Collections>
    </maecBundle:Collections>
</maecBundle:MAEC_Bundle>
```

Signed-off-by: Luigi Mori <l@isidora.org>