### PR TITLE
README.rst had utf-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_version():
         raise AttributeError("Package does not have a __version__")
 
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
 
 


### PR DESCRIPTION
Just a small thing. I ran into some issues installing this package in AWS user-data because of the utf-8 encoding in README.rst.